### PR TITLE
feature/13_notification_settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'faker'
+  gem 'factory_bot_rails'
+  gem 'rspec-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     crass (1.0.6)
     debug_inspector (0.0.3)
     deep_merge (1.2.1)
+    diff-lcs (1.4.2)
     dry-configurable (0.11.6)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
@@ -117,6 +118,11 @@ GEM
       dry-schema (~> 1.5)
     erubi (1.9.0)
     execjs (2.7.0)
+    factory_bot (6.0.2)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.0.0)
+      factory_bot (~> 6.0.0)
+      railties (>= 5.0.0)
     faker (2.13.0)
       i18n (>= 1.6, < 2)
     faraday (1.0.1)
@@ -265,6 +271,23 @@ GEM
       redis (>= 4, < 5)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-rails (4.0.1)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.9)
+      rspec-expectations (~> 3.9)
+      rspec-mocks (~> 3.9)
+      rspec-support (~> 3.9)
+    rspec-support (3.9.3)
     rubocop (0.86.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -359,6 +382,7 @@ DEPENDENCIES
   byebug
   carrierwave
   config
+  factory_bot_rails
   faker
   font-awesome-sass (~> 5.4.1)
   html2slim
@@ -375,6 +399,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-i18n
   redis-rails
+  rspec-rails
   rubocop
   rubocop-rails
   sass-rails (~> 5.0)


### PR DESCRIPTION
# 概要
通知をするかしないかをユーザーが設定できる機能を実装

# コメント
通知の可否をチェックつけて更新する時に、check_boxを使うとdefaultで０か１を入れてくれるので、destroyアクションを設けなくても簡単に設定をカスタマイズできるのが楽でした。仕組みは単純ですが、その手があったか、とちょっと感動しました。
